### PR TITLE
Pagination previous link not aligned

### DIFF
--- a/src/View/Helper/PaginatorHelper.php
+++ b/src/View/Helper/PaginatorHelper.php
@@ -18,9 +18,9 @@ class PaginatorHelper extends \Cake\View\Helper\PaginatorHelper
             'nextActive' => '<li class="next"><a rel="next" aria-label="Next" href="{{url}}">' .
                             '<span aria-hidden="true">{{text}}</span></a></li>',
             'nextDisabled' => '<li class="next disabled"><a><span aria-hidden="true">{{text}}</span></a></li>',
-            'prevActive' => '<li class="prev"><a rel="prev" aria-label="Previous" href="{{url}}">' .
+            'prevActive' => '<li class="previous"><a rel="prev" aria-label="Previous" href="{{url}}">' .
                             '<span aria-hidden="true">{{text}}</span></a></li>',
-            'prevDisabled' => '<li class="prev disabled"><a><span aria-hidden="true">{{text}}</span></a></li>',
+            'prevDisabled' => '<li class="previous disabled"><a><span aria-hidden="true">{{text}}</span></a></li>',
             'current' => '<li class="active"><span>{{text}} <span class="sr-only">(current)</span></span></li>',
         ] + $this->_defaultConfig['templates'];
 

--- a/tests/TestCase/View/Helper/PaginatorHelperTest.php
+++ b/tests/TestCase/View/Helper/PaginatorHelperTest.php
@@ -126,7 +126,7 @@ class PaginatorHelperTest extends TestCase
         $result = $this->Paginator->numbers(['prev' => true, 'next' => true]);
         $expected = [
             'ul' => ['class' => 'pagination'],
-            ['li' => ['class' => 'prev disabled']], ['a' => []], ['span' => ['aria-hidden' => 'true']], '&laquo;', '/span', '/a', '/li',
+            ['li' => ['class' => 'previous disabled']], ['a' => []], ['span' => ['aria-hidden' => 'true']], '&laquo;', '/span', '/a', '/li',
             '<li', ['a' => ['href' => '/index?page=4']], '4', '/a', '/li',
             '<li', ['a' => ['href' => '/index?page=5']], '5', '/a', '/li',
             '<li', ['a' => ['href' => '/index?page=6']], '6', '/a', '/li',


### PR DESCRIPTION
Bootstrap3 need classname "previous" instead "prev"
